### PR TITLE
Fix up a breakage in old examples and clean up

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,7 +1,7 @@
 import { REST, Routes } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { clientId, guildId, token } = config;
 import { fileURLToPath } from 'url';
 

--- a/examples/grass-toucher/config.json
+++ b/examples/grass-toucher/config.json
@@ -1,5 +1,1 @@
-{
-	"token": "your-token-here",
-    "clientId": "your-clientId-here",
-	"guildId": "your-serverId-here"
-}
+../../config.json

--- a/examples/grass-toucher/deploy-commands.js
+++ b/examples/grass-toucher/deploy-commands.js
@@ -1,7 +1,7 @@
 import { REST, Routes } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { clientId, guildId, token } = config;
 import { fileURLToPath } from 'url';
 

--- a/examples/grass-toucher/index.js
+++ b/examples/grass-toucher/index.js
@@ -1,5 +1,5 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { token } = config;
 import fs from 'node:fs';
 import path from 'node:path';

--- a/examples/grass-toucher/package.json
+++ b/examples/grass-toucher/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-	"type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/examples/joke-candy-bot/config.json
+++ b/examples/joke-candy-bot/config.json
@@ -1,5 +1,1 @@
-{
-	"token": "your-token-here",
-    "clientId": "your-clientId-here",
-	"guildId": "your-serverId-here"
-}
+../../config.json

--- a/examples/joke-candy-bot/deploy-commands.js
+++ b/examples/joke-candy-bot/deploy-commands.js
@@ -1,5 +1,5 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { token } = config;
 import fs from 'node:fs';
 import path from 'node:path';

--- a/examples/joke-candy-bot/index.js
+++ b/examples/joke-candy-bot/index.js
@@ -1,5 +1,5 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { token } = config;
 import fs from 'node:fs';
 import path from 'node:path';

--- a/examples/jumpscare/deploy-commands.js
+++ b/examples/jumpscare/deploy-commands.js
@@ -1,7 +1,7 @@
 import { REST, Routes } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { clientId, guildId, token } = config;
 import { fileURLToPath } from 'url';
 

--- a/examples/jumpscare/index.js
+++ b/examples/jumpscare/index.js
@@ -1,6 +1,6 @@
 import { Client, Collection, Events, GatewayIntentBits, ChannelType } from 'discord.js';
 import { joinVoiceChannel, VoiceConnectionStatus, createAudioPlayer, createAudioResource, AudioPlayerStatus } from '@discordjs/voice';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { token } = config;
 import fs from 'node:fs';
 import path from 'node:path';

--- a/examples/mudae-clone/config.json
+++ b/examples/mudae-clone/config.json
@@ -1,5 +1,1 @@
-{
-	"token": "your-token-here",
-    "clientId": "-your-clientId-here",
-	"guildId": "your-serverid-here"
-}
+../../config.json

--- a/examples/mudae-clone/deploy-commands.js
+++ b/examples/mudae-clone/deploy-commands.js
@@ -1,7 +1,7 @@
 import { REST, Routes } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { clientId, guildId, token } = config;
 import { fileURLToPath } from 'url';
 

--- a/examples/mudae-clone/index.js
+++ b/examples/mudae-clone/index.js
@@ -1,5 +1,5 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { token } = config;
 import fs from 'node:fs';
 import path from 'node:path';

--- a/examples/vocabulary-trainer/config.json
+++ b/examples/vocabulary-trainer/config.json
@@ -1,5 +1,1 @@
-{
-	"token": "your-token-here",
-  "clientId": "your-clientId-here",
-	"guildId": "your-serverId-here"
-}
+../../config.json

--- a/examples/vocabulary-trainer/deploy-commands.js
+++ b/examples/vocabulary-trainer/deploy-commands.js
@@ -1,7 +1,7 @@
 import { REST, Routes } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 import { fileURLToPath } from 'url';
 
 const { clientId, guildId, token } = config;

--- a/examples/vocabulary-trainer/events/clientReady.js
+++ b/examples/vocabulary-trainer/events/clientReady.js
@@ -3,7 +3,7 @@ import schedule from "node-schedule";
 
 import { setRules, obtainRules } from './utils/rules.js';
 import { spawnMonster, checkHealth } from './utils/monsters.js';
-import config from '../config.json' assert { type: "json" };
+import config from '../config.json' with { type: "json" };
 const { guildId } = config;
 
 const name = Events.ClientReady;

--- a/examples/vocabulary-trainer/index.js
+++ b/examples/vocabulary-trainer/index.js
@@ -2,7 +2,7 @@ import { Client, GatewayIntentBits, Collection } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { token, guildId } = config;
 
 // Create a new bot client

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
-import config from './config.json' assert { type: "json" };
+import config from './config.json' with { type: "json" };
 const { token } = config;
 import fs from 'node:fs';
 import path from 'node:path';


### PR DESCRIPTION
* Since Spring last year, the `assert` syntax in imports has been deprecated. It should now be `with`, and this branch fixes that
* Unify all the `config.json` files to all just point to one, so students only have to set tokens in one place to run all the bots