### PR TITLE
Automatically run [deploy-commands.js] when commands change

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "nodemon --no-colours index.js"
+    "start": "nodemon --no-colours -x 'node deploy-commands && node index.js'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The way it works is that it uses `util.inspect` to check the dump of the `commands` array. So now `deploy-commands.js` is clever enough to check the current `commands` array against the dump of the last one, and only redeploy commands if it changed.

(It also dumps the API key in asw. Without it, you might change the API key and then the script wouldn't be clever enough to redeploy even though it should.)